### PR TITLE
Add tool change

### DIFF
--- a/src/cobotta_control/cobotta_pro_control.py
+++ b/src/cobotta_control/cobotta_pro_control.py
@@ -15,6 +15,7 @@ import psutil
 import multiprocessing as mp
 import threading
 
+import modern_robotics as mr
 import numpy as np
 from dotenv import load_dotenv
 
@@ -51,6 +52,7 @@ filter_kind: Literal[
     "state_and_target_diff",
     "moveit_servo_humble",
     "control_and_target_diff",
+    "feedback_pd_traj",
 ] = "original"
 speed_limits = np.array([240, 200, 240, 300, 300, 475])
 speed_limit_ratio = 0.35
@@ -472,13 +474,24 @@ class Cobotta_Pro_CON:
                     self.last_control = state
                     _filter = SMAFilter(n_windows=n_windows)
                     _filter.reset(state)
+                elif filter_kind == "feedback_pd_traj":
+                    N = 6
+                    Tf = t_intv * (N - 1)
+                    method = 5
+                    Kp = 0.6
+                    Kd = 0.02
+                    prev_error = np.zeros(6)
+                    pd_step = 0
 
                 # 速度制限をフィルタの手前にも入れてみる
                 if True:
-                    assert filter_kind == "original"
+                    assert filter_kind in ["original", "feedback_pd_traj"]
                     self.last_target_delayed_velocity = np.zeros(6)
 
-                self.last_control_velocity = np.zeros(6)
+                if filter_kind == "original":
+                    self.last_control_velocity = np.zeros(6)
+                elif filter_kind == "feedback_pd_traj":
+                    self.last_control_velocity = np.zeros((N - 1, 6))
                 # ロボットにコマンドを送る前は、非常停止が押されているかを
                 # スレーブモードが解除されているかで確認する
                 if self.pose[37] != 1:
@@ -513,7 +526,7 @@ class Cobotta_Pro_CON:
             sw.lap("1st speed limit")
             # 速度制限をフィルタの手前にも入れてみる
             if True:
-                assert filter_kind == "original"
+                assert filter_kind in ["original", "feedback_pd_traj"]
                 target_diff = target_delayed - self.last_target_delayed
                 # 速度制限
                 dt = now - self.last
@@ -603,37 +616,94 @@ class Cobotta_Pro_CON:
                 last_target_filtered = _filter.previous_filtered_measurement
                 target_filtered = _filter.filter(target_aligned)
                 target_diff = target_filtered - last_target_filtered
+            elif filter_kind == "feedback_pd_traj":
+                if pd_step == 0:
+                    error = target_delayed - state
+                    d_error = (error - prev_error) / Tf
+                    mse = np.mean(error ** 2)
+                    target_goal = state + Kp * error + Kd * d_error
+                    prev_error = error
+                    target_steps = mr.JointTrajectory(
+                        state.tolist(),
+                        target_goal.tolist(),
+                        Tf,
+                        N,
+                        method,
+                    )
+                    # 速度制限
+                    dt = t_intv
+                    # [N - 1, 6]
+                    target_diffs = np.diff(target_steps, axis=0)
+                    vs = target_diffs / dt
+                    ratios = np.abs(vs) / (speed_limit_ratio * speed_limits)[None, :]
+                    max_ratio = np.max(ratios)
+                    if max_ratio > 1:
+                        vs /= max_ratio
+
+                    # 加速度制限
+                    # [N, 6]
+                    vs_ = np.concatenate([self.last_control_velocity[[-1], :], vs], axis=0)
+                    # [N - 1, 6]
+                    as_ = np.diff(vs_, axis=0) / dt
+                    accel_ratios = np.abs(as_) / (accel_limit_ratio * accel_limits)[None, :]
+                    accel_max_ratio = np.max(accel_ratios)
+                    if accel_max_ratio > 1:
+                        as_ /= accel_max_ratio
+                    # [N - 1, 6]
+                    vs_ = vs_[0][None, :] + np.cumsum(as_, axis=0) * dt
+
+                    target_diffs_speed_limited = vs_ * dt
+                    # 速度がしきい値より小さければ静止させ無駄なドリフトを避ける
+                    # NOTE: スレーブモードを落とさないためには前の速度が十分小さいとき (しきい値は不明) 
+                    # にしか静止させてはいけない
+                    for i in range(N - 1):
+                        if np.all(target_diffs_speed_limited[i] / dt < stopped_velocity_eps):
+                            target_diffs_speed_limited[i] = np.zeros_like(
+                                target_diffs_speed_limited[i])
+                            vs_[i] = target_diffs_speed_limited[i] / dt
+
+                    # [N - 1, 6]
+                    target_steps_speed_limited = target_steps[0][None, :] + np.cumsum(vs_, axis=0) * dt
+                    self.last_control_velocity = vs_
+
+                target_step_speed_limited = target_steps_speed_limited[pd_step]
+
+                # Next step
+                pd_step += 1
+                if pd_step == N - 1:
+                    pd_step = 0
             else:
                 raise ValueError
 
             sw.lap("2nd speed limit")
-            # 速度制限
-            dt = now - self.last
-            v = target_diff / dt
-            ratio = np.abs(v) / (speed_limit_ratio * speed_limits)
-            max_ratio = np.max(ratio)
-            if max_ratio > 1:
-                v /= max_ratio
-            target_diff_speed_limited = v * dt
+            if filter_kind != "feedback_pd_traj":
+                # 速度制限
+                dt = now - self.last
+                v = target_diff / dt
+                ratio = np.abs(v) / (speed_limit_ratio * speed_limits)
+                max_ratio = np.max(ratio)
+                if max_ratio > 1:
+                    v /= max_ratio
+                target_diff_speed_limited = v * dt
 
-            # 加速度制限
-            a = (v - self.last_control_velocity) / dt
-            accel_ratio = np.abs(a) / (accel_limit_ratio * accel_limits)
-            accel_max_ratio = np.max(accel_ratio)
-            if accel_max_ratio > 1:
-                a /= accel_max_ratio
-            v = self.last_control_velocity + a * dt
-            target_diff_speed_limited = v * dt
+                # 加速度制限
+                a = (v - self.last_control_velocity) / dt
+                accel_ratio = np.abs(a) / (accel_limit_ratio * accel_limits)
+                accel_max_ratio = np.max(accel_ratio)
+                if accel_max_ratio > 1:
+                    a /= accel_max_ratio
+                v = self.last_control_velocity + a * dt
+                target_diff_speed_limited = v * dt
 
-            # 速度がしきい値より小さければ静止させ無駄なドリフトを避ける
-            # NOTE: スレーブモードを落とさないためには前の速度が十分小さいとき (しきい値は不明) 
-            # にしか静止させてはいけない
-            if np.all(target_diff_speed_limited / dt < stopped_velocity_eps):
-                target_diff_speed_limited = np.zeros_like(
-                    target_diff_speed_limited)
-                v = target_diff_speed_limited / dt
+                # 速度がしきい値より小さければ静止させ無駄なドリフトを避ける
+                # NOTE: スレーブモードを落とさないためには前の速度が十分小さいとき (しきい値は不明) 
+                # にしか静止させてはいけない
+                if np.all(target_diff_speed_limited / dt < stopped_velocity_eps):
+                    target_diff_speed_limited = np.zeros_like(
+                        target_diff_speed_limited)
+                    v = target_diff_speed_limited / dt
 
-            self.last_control_velocity = v
+                self.last_control_velocity = v
 
             sw.lap("Get control")
             # 平滑化の種類による対応
@@ -649,6 +719,8 @@ class Cobotta_Pro_CON:
                 control = state + target_diff_speed_limited
             elif filter_kind == "control_and_target_diff":
                 control = last_target_filtered + target_diff_speed_limited
+            elif filter_kind == "feedback_pd_traj":
+                control = target_step_speed_limited
             else:
                 raise ValueError
 

--- a/src/cobotta_control/cobotta_pro_control.py
+++ b/src/cobotta_control/cobotta_pro_control.py
@@ -362,6 +362,9 @@ class Cobotta_Pro_CON:
                     break
                 continue
 
+            # ツールチェンジなど後の制御可能フラグ
+            self.pose[41] = 1
+
             # 目標値を取得しているかを確認
             if self.pose[20] != 1:
                 time.sleep(t_intv)
@@ -827,7 +830,10 @@ class Cobotta_Pro_CON:
  
         # スレーブモード解除可能な状態になったら即時に解除しないと指令値生成遅延になる
         self.leave_servo_mode()       
- 
+
+         # ツールチェンジなど後の制御可能フラグ
+        self.pose[41] = 0
+
         hand_thread.join()
         if error_event.is_set():
             # TODO: これで例外発生元のスタックトレースが取得できればこれで十分
@@ -1262,6 +1268,7 @@ class Cobotta_Pro_CON:
             if next_tool_id != 0:
                 try:
                     self.logger.info(f"Tool change to: {next_tool_id}")
+                    self.pose[41] = 0
                     self.tool_change(next_tool_id)
                     self.pose[18] = 1
                 except Exception as e:
@@ -1270,6 +1277,7 @@ class Cobotta_Pro_CON:
                     self.pose[18] = 2
                 finally:
                     self.pose[17] = 0
+                    self.pose[41] = 1
                     break
 
     def jog_joint(self, joint: int, direction: float) -> None:

--- a/src/cobotta_control/cobotta_pro_monitor.py
+++ b/src/cobotta_control/cobotta_pro_monitor.py
@@ -224,7 +224,7 @@ class Cobotta_Pro_MON:
             try:
                 actual_tcp_pose = self.robot.get_current_pose()
             except Exception as e:
-                self.logger.error("Error in get_current_pose: ")
+                self.logger.error("Error in get_current_pose (maybe non-critical): ")
                 self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 actual_tcp_pose = None
@@ -232,7 +232,7 @@ class Cobotta_Pro_MON:
             try:
                 actual_joint = self.robot.get_current_joint()
             except Exception as e:
-                self.logger.error("Error in get_current_joint: ")
+                self.logger.error("Error in get_current_joint (maybe non-critical): ")
                 self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 actual_joint = None
@@ -259,7 +259,7 @@ class Cobotta_Pro_MON:
             try:
                 forces = self.robot.ForceValue()
             except Exception as e:
-                self.logger.error("Error in ForceValue: ")
+                self.logger.error("Error in ForceValue (maybe non-critical): ")
                 self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 forces = None
@@ -290,9 +290,7 @@ class Cobotta_Pro_MON:
             try:
                 enabled = self.robot.is_enabled()
             except Exception as e:
-                self.logger.warning(
-                    "Somehow failed in checking if robot is enabled. "
-                    "Enabled value may be incorrect.")
+                self.logger.warning("Error in is_enabled (maybe non-critical): ")
                 self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 enabled = False
@@ -303,9 +301,7 @@ class Cobotta_Pro_MON:
             try:
                 is_in_servo_mode = self.robot.is_in_servo_mode()
             except Exception as e:
-                self.logger.warning(
-                    "Somehow failed in checking if robot is in servo mode. "
-                    "Enabled value may be incorrect.")
+                self.logger.warning("Error in is_in_servo_mode (maybe non-critical): ")
                 self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
             # 切り替わるときにログを出す
@@ -329,7 +325,7 @@ class Cobotta_Pro_MON:
                     try:
                         errors = self.robot.get_cur_error_info_all()
                     except Exception as e:
-                        self.logger.error("Error in get_cur_error_info_all: ")
+                        self.logger.error("Error in get_cur_error_info_all (maybe non-critical): ")
                         self.logger.error(f"{self.robot.format_error(e)}")
                         self.reconnect_after_timeout(e)
                         errors = []
@@ -345,9 +341,7 @@ class Cobotta_Pro_MON:
                     try:
                         is_emergency_stopped = self.robot.is_emergency_stopped()
                     except Exception as e:
-                        self.logger.warning(
-                            "Somehow failed in checking if robot is emergency stopped."
-                            "Thus value may be incorrect.")
+                        self.logger.warning("Error in is_emergency_stopped (maybe non-critical): ")
                         self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
                         self.reconnect_after_timeout(e)
             # 切り替わるときにログを出す

--- a/src/cobotta_control/cobotta_pro_monitor.py
+++ b/src/cobotta_control/cobotta_pro_monitor.py
@@ -172,7 +172,7 @@ class Cobotta_Pro_MON:
                     is_in_tool_change = True
                     self.logger.info("Tool change started")
             else:
-                if is_in_tool_change:
+                if self.pose[41] == 1 and is_in_tool_change:
                     is_in_tool_change = False
                     status_tool_change = bool(self.pose[18] == 1)
                     self.logger.info("Tool change finished")
@@ -199,7 +199,7 @@ class Cobotta_Pro_MON:
                 if not is_put_down_box:
                     is_put_down_box = True
             else:
-                if is_put_down_box:
+                if self.pose[41] == 1 and is_put_down_box:
                     is_put_down_box = False
                     status_put_down_box = bool(self.pose[22] == 1)
             # 終了した場合のみキーを追加
@@ -213,7 +213,7 @@ class Cobotta_Pro_MON:
                 if not line_cut:
                     line_cut = True
             else:
-                if line_cut:
+                if self.pose[41] == 1 and line_cut:
                     line_cut = False
                     status_line_cut = bool(self.pose[39] == 1)
             # 終了した場合のみキーを追加

--- a/src/cobotta_control/cobotta_pro_monitor.py
+++ b/src/cobotta_control/cobotta_pro_monitor.py
@@ -224,16 +224,20 @@ class Cobotta_Pro_MON:
             try:
                 actual_tcp_pose = self.robot.get_current_pose()
             except Exception as e:
-                self.logger.error("Error in get_current_pose (maybe non-critical): ")
-                self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
+                if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                    self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                else:
+                    self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 actual_tcp_pose = None
             # 関節
             try:
                 actual_joint = self.robot.get_current_joint()
             except Exception as e:
-                self.logger.error("Error in get_current_joint (maybe non-critical): ")
-                self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
+                if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                    self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                else:
+                    self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 actual_joint = None
             if actual_joint is not None:
@@ -259,8 +263,10 @@ class Cobotta_Pro_MON:
             try:
                 forces = self.robot.ForceValue()
             except Exception as e:
-                self.logger.error("Error in ForceValue (maybe non-critical): ")
-                self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
+                if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                    self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                else:
+                    self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 forces = None
             if forces is not None:
@@ -290,8 +296,10 @@ class Cobotta_Pro_MON:
             try:
                 enabled = self.robot.is_enabled()
             except Exception as e:
-                self.logger.warning("Error in is_enabled (maybe non-critical): ")
-                self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                    self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                else:
+                    self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
                 enabled = False
             actual_joint_js["enabled"] = enabled
@@ -301,8 +309,10 @@ class Cobotta_Pro_MON:
             try:
                 is_in_servo_mode = self.robot.is_in_servo_mode()
             except Exception as e:
-                self.logger.warning("Error in is_in_servo_mode (maybe non-critical): ")
-                self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                    self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                else:
+                    self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                 self.reconnect_after_timeout(e)
             # 切り替わるときにログを出す
             if  is_in_servo_mode != last_is_in_servo_mode:
@@ -325,7 +335,10 @@ class Cobotta_Pro_MON:
                     try:
                         errors = self.robot.get_cur_error_info_all()
                     except Exception as e:
-                        self.logger.error("Error in get_cur_error_info_all (maybe non-critical): ")
+                        if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                            self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                        else:
+                            self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                         self.logger.error(f"{self.robot.format_error(e)}")
                         self.reconnect_after_timeout(e)
                         errors = []
@@ -341,8 +354,10 @@ class Cobotta_Pro_MON:
                     try:
                         is_emergency_stopped = self.robot.is_emergency_stopped()
                     except Exception as e:
-                        self.logger.warning("Error in is_emergency_stopped (maybe non-critical): ")
-                        self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                        if type(e) is ORiNException and self.robot.is_error_level_0(e):
+                            self.logger.warning(f"{self.robot.format_error_wo_desc(e)}")
+                        else:
+                            self.logger.error(f"{self.robot.format_error_wo_desc(e)}")
                         self.reconnect_after_timeout(e)
             # 切り替わるときにログを出す
             if is_emergency_stopped != last_is_emergency_stopped:

--- a/src/cobotta_control/cobotta_pro_mqtt_control.py
+++ b/src/cobotta_control/cobotta_pro_mqtt_control.py
@@ -263,6 +263,7 @@ class ProcessManager:
         # [38]: カッター移動の実行フラグ。0: 終了。1: 開始
         # [39]: カッター移動の完了状態。0: 未定義。1: 成功。2: 失敗
         # [40]: ハンドの把持力。
+        # [41]: ツールチェンジなど後の制御可能フラグ。0: 制御不可。1: 制御可能
         self.ar = np.ndarray((SHM_SIZE,), dtype=np.dtype("float32"), buffer=self.sm.buf) # 共有メモリ上の Array
         self.ar[:] = 0
         self.manager = multiprocessing.Manager()

--- a/src/cobotta_control/denso_robot.py
+++ b/src/cobotta_control/denso_robot.py
@@ -77,13 +77,13 @@ E_GRIP_NOT_DETECTED = original_error_to_python_error(0x8350048f)
 
 path = os.path.join(os.path.dirname(__file__),"..","vendor","denso_cobotta","error_list.xlsx")
 df = pd.read_excel(path)
-E_VEL_AUTO_RECOVERABLE_SET = set(df.loc[~df["自動復帰対象速度エラー"].astype(bool), "コード"].apply(
+E_VEL_AUTO_RECOVERABLE_SET = set(df.loc[df["自動復帰対象速度エラー"].astype(bool), "コード"].apply(
     lambda x: original_error_to_python_error(int(x, 16))
 ))
-E_ACCEL_AUTO_RECOVERABLE_SET = set(df.loc[~df["自動復帰対象加速度エラー"].astype(bool), "コード"].apply(
+E_ACCEL_AUTO_RECOVERABLE_SET = set(df.loc[df["自動復帰対象加速度エラー"].astype(bool), "コード"].apply(
     lambda x: original_error_to_python_error(int(x, 16))
 ))
-E_AUTO_RECOVERABLE_SET = set(df.loc[~df["自動復帰対象エラー"].astype(bool), "コード"].apply(
+E_AUTO_RECOVERABLE_SET = set(df.loc[df["自動復帰対象エラー"].astype(bool), "コード"].apply(
     lambda x: original_error_to_python_error(int(x, 16))
 ))
 E_EMERGENCY_STOP_SET = set(df.loc[df["非常停止エラー"].astype(bool), "コード"].apply(

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,3 +6,4 @@ psutil==7.0.0
 python-dotenv==1.1.0
 pyqtgraph==0.13.7
 PyQt6==6.9.1
+modern-robotics==1.1.1


### PR DESCRIPTION
修正点:
- VRにツールチェンジ終了メッセージを送ってから、ロボットの姿勢をコントローラで制御できるまでに3−5秒のラグがあったので、メッセージを送るタイミングを修正してラグを1秒以下に短縮
- モニタプロセス中の、ロボット由来のエラーのうち、レベル0（ロボット動作への影響なし）のエラーが時々出てしまうが、ログレベルをERRORからWARNINGに変更して基本的に問題ないことをわかりやすくしました
- ロボットをより滑らかに遅延なく動かすため、劉様がPiperのロボット側のコードに使用していた平滑化方法（5次スプライン補間 + PD制御のオプションを追加。但し速度制限がある場合に上手くいっていないため、このオプションはデフォルトでは使用しません